### PR TITLE
Fix localhost

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,7 @@ function removeAllCookiesFromDomain(currentTabUrl) {
     var url = (new URL(currentTabUrl)).hostname;
     // Don't split if domain is localhost
     if (url != 'localhost') {
-      var splittedUrl = (new URL(currentTabUrl)).hostname.split('.');
+      var splittedUrl = url.split('.');
       var urlPieces = splittedUrl.pop(); // *.de
 
       // Each time one more Subdomain

--- a/js/main.js
+++ b/js/main.js
@@ -46,7 +46,7 @@ function removeAllCookiesFromDomain(currentTabUrl) {
       // remove cookies for localhost
       chrome.cookies.getAll({domain: "localhost"}, function (cookies) {
           for (var i = 0; i < cookies.length; i++) {
-              var scheme = "";
+              var scheme = "http://";
               if(cookies[i].secure)
                   scheme = "https://";
 

--- a/js/main.js
+++ b/js/main.js
@@ -5,39 +5,54 @@ chrome.browserAction.onClicked.addListener(function (tab) {
 });
 
 function removeAllCookiesFromDomain(currentTabUrl) {
+    var url = (new URL(currentTabUrl)).hostname;
+    // Don't split if domain is localhost
+    if (url != 'localhost') {
+      var splittedUrl = (new URL(currentTabUrl)).hostname.split('.');
+      var urlPieces = splittedUrl.pop(); // *.de
 
-    var splittedUrl = (new URL(currentTabUrl)).hostname.split('.');
-    var urlPieces = splittedUrl.pop(); // *.de
+      // Each time one more Subdomain
+      while (splittedUrl.length > 0) {
 
-    // Each time one more Subdomain
-    while (splittedUrl.length > 0) {
+          urlPieces = splittedUrl.pop() + "." + urlPieces; // first loop: seamex.de
 
-        urlPieces = splittedUrl.pop() + "." + urlPieces; // first loop: seamex.de
+          // Without Dot
+          chrome.cookies.getAll({domain: urlPieces}, function (cookies) {
+              for (var i = 0; i < cookies.length; i++) {
+                  var scheme = "http://";
 
-        // Without Dot
-        chrome.cookies.getAll({domain: urlPieces}, function (cookies) {
-            for (var i = 0; i < cookies.length; i++) {
-                var scheme = "http://";
+                  if(cookies[i].secure)
+                      scheme = "https://";
 
-                if(cookies[i].secure)
-                    scheme = "https://";
+                  // Protocol agnostic
+                  chrome.cookies.remove({url: scheme + urlPieces + cookies[i].path, name: cookies[i].name});
+              }
+          });
 
-                // Protocol agnostic
-                chrome.cookies.remove({url: scheme + urlPieces + cookies[i].path, name: cookies[i].name});
-            }
-        });
+          // With dot
+          chrome.cookies.getAll({domain: "." + urlPieces}, function (cookies) {
+              for (var i = 0; i < cookies.length; i++) {
+                  var scheme = "http://";
 
-        // With dot
-        chrome.cookies.getAll({domain: "." + urlPieces}, function (cookies) {
-            for (var i = 0; i < cookies.length; i++) {
-                var scheme = "http://";
+                  if(cookies[i].secure)
+                      scheme = "https://";
 
-                if(cookies[i].secure)
-                    scheme = "https://";
+                  // Protocol agnostic
+                  chrome.cookies.remove({url: scheme + urlPieces + cookies[i].path, name: cookies[i].name});
+              }
+          });
+      }
+    } else {
+      // remove cookies for localhost
+      chrome.cookies.getAll({domain: "localhost"}, function (cookies) {
+          for (var i = 0; i < cookies.length; i++) {
+              var scheme = "";
+              if(cookies[i].secure)
+                  scheme = "https://";
 
-                // Protocol agnostic
-                chrome.cookies.remove({url: scheme + urlPieces + cookies[i].path, name: cookies[i].name});
-            }
-        });
+              // Protocol agnostic
+              chrome.cookies.remove({url: scheme + "localhost" + cookies[i].path, name: cookies[i].name});
+          }
+      });
     }
 }


### PR DESCRIPTION
Fix For #2 
It is currently not possible to delete cookies on localhost (p.e. for development)

This fix enables localhost possibility.

It leaves all the old code and just removes the cookie a bit differently, when the url is localhost (No splits etc. needed).